### PR TITLE
Add a custom attribute to decorate Document model classes in Mobile Services

### DIFF
--- a/azure-mobileservices-net/sample/Documents.MobileServices.Todolist/Controllers/TodoItemDocumentController.cs
+++ b/azure-mobileservices-net/sample/Documents.MobileServices.Todolist/Controllers/TodoItemDocumentController.cs
@@ -22,7 +22,7 @@ namespace Documents.MobileServices.Controllers
         protected override void Initialize(HttpControllerContext controllerContext)
         {
             base.Initialize(controllerContext);
-            DomainManager = new DocumentEntityDomainManager<DocumentTodoItem>("AMSDocumentDB", "todolist", Request, Services);
+            DomainManager = new DocumentEntityDomainManager<DocumentTodoItem>(Request, Services);
         }
 
         public IQueryable<DocumentTodoItem> GetAllTodoItems()

--- a/azure-mobileservices-net/sample/Documents.MobileServices.Todolist/DataObjects/DocumentTodoItem.cs
+++ b/azure-mobileservices-net/sample/Documents.MobileServices.Todolist/DataObjects/DocumentTodoItem.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.MobileServices;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -7,6 +8,7 @@ using System.Web;
 
 namespace Documents.MobileServices.Todolist.DataObjects
 {
+    [Document("todolist", "AMSDocumentDB")]
     public class DocumentTodoItem : Resource
     {
 

--- a/azure-mobileservices-net/src/Documents.MobileServices/DocumentAttribute.cs
+++ b/azure-mobileservices-net/src/Documents.MobileServices/DocumentAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Documents.MobileServices
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class DocumentAttribute : Attribute
+    {
+        public string DatabaseId { get; private set; }
+
+        public string CollectionId { get; private set; }
+
+        public DocumentAttribute(string databaseId, string collectionId)
+        {
+            DatabaseId = databaseId;
+            CollectionId = collectionId;
+        }
+    }
+}

--- a/azure-mobileservices-net/src/Documents.MobileServices/DocumentEntityDomainManager.cs
+++ b/azure-mobileservices-net/src/Documents.MobileServices/DocumentEntityDomainManager.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Documents.Linq;
 using System.Web.Http;
 using System.Configuration;
+using Microsoft.Azure.Documents.MobileServices;
 
 namespace Documents.MobileServices
 {
@@ -33,7 +34,19 @@ namespace Documents.MobileServices
                 _databaseId = databaseId;
             }
 
-            public async Task<bool> DeleteAsync(string id)
+        public DocumentEntityDomainManager(HttpRequestMessage request, ApiServices services)
+        {
+            var attribute = typeof(TDocument).GetCustomAttributes(typeof(DocumentAttribute), true).FirstOrDefault() as DocumentAttribute;
+            if (attribute == null)
+                throw new ArgumentException("the model class must be decorated with the Document attribute");
+
+            Request = request;
+            Services = services;
+            _collectionId = attribute.CollectionId;
+            _databaseId = attribute.DatabaseId;
+        }
+
+        public async Task<bool> DeleteAsync(string id)
             {
                 try
                 {

--- a/azure-mobileservices-net/src/Documents.MobileServices/Documents.MobileServices.csproj
+++ b/azure-mobileservices-net/src/Documents.MobileServices/Documents.MobileServices.csproj
@@ -155,6 +155,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DocumentAttribute.cs" />
     <Compile Include="DocumentController.cs" />
     <Compile Include="DocumentEntityDomainManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
 Add a custom attribute for Mobile Services that allows to specify on the model class the database and collection in which to store the document, without the need to write these values in the Controller.
