### PR TITLE
Use comments in the GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,20 +5,22 @@ about: Create a report to help us improve
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
+
 
 **To Reproduce**
-Steps to reproduce the behavior. If you can include code snippets or links to repositories containing a repro of the issue that can helps us in detecting the scenario it would speed up the resolution.
+<!-- Steps to reproduce the behavior. If you can include code snippets or links to repositories containing a repro of the issue that can helps us in detecting the scenario it would speed up the resolution. -->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen.-->
 
 **Actual behavior**
-Provide a description of the actual behavior observed. 
+<!-- Provide a description of the actual behavior observed. -->
 
 **Environment summary**
+
 SDK Version:
-OS Version (e.g. Windows, Linux, MacOSX)
+OS Version (e.g. Windows, Linux, MacOSX): 
 
 **Additional context**
-Add any other context about the problem here (for example, complete stack traces or logs).
+<!-- Add any other context about the problem here (for example, complete stack traces or logs).-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,13 +5,13 @@ about: Suggest an idea for this project
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
Comments allow for a description that won't be shown in the GitHub issue when it's published (so folks don't have to delete it each time and it feels more like guidance).

NOTE: This is just a small drive-by PR that I happened to notice. If it's not welcome I won't be offended if it's closed. 👍 