### PR TITLE
Fix possible memory leaks when not disposing query

### DIFF
--- a/Demo/ChangeFeed-AutomaticVehicleLocatingSystem/IoTEmulator/AzureCosmosDBLib/Client.cs
+++ b/Demo/ChangeFeed-AutomaticVehicleLocatingSystem/IoTEmulator/AzureCosmosDBLib/Client.cs
@@ -91,19 +91,20 @@
 
         public static async Task<IEnumerable<T>> GetItemsAsync(Expression<Func<T, bool>> predicate, string documentId)
         {
-            IDocumentQuery<T> query = client.CreateDocumentQuery<T>(UriFactory.CreateDocumentUri(_database, _collection, documentId),
+            using (var query = client.CreateDocumentQuery<T>(UriFactory.CreateDocumentUri(_database, _collection, documentId),
                 new FeedOptions { MaxItemCount = -1 })
                 .Where(predicate)
-                .AsDocumentQuery();
-
-            List<T> results = new List<T>();
-            while (query.HasMoreResults)
+                .AsDocumentQuery())
             {
-                
-                results.AddRange(await query.ExecuteNextAsync<T>());
-            }
+                List<T> results = new List<T>();
+                while (query.HasMoreResults)
+                {
 
-            return results;
+                    results.AddRange(await query.ExecuteNextAsync<T>());
+                }
+
+                return results;
+            }
         }
 
         public static async Task<Document> CreateItemAsync(T item)

--- a/samples/code-samples/IndexManagement/Program.cs
+++ b/samples/code-samples/IndexManagement/Program.cs
@@ -395,17 +395,19 @@ namespace DocumentDB.Samples.IndexManagement
         {
             try
             {
-                IDocumentQuery<dynamic> documentQuery = client.CreateDocumentQuery(
+                using (IDocumentQuery<dynamic> documentQuery = client.CreateDocumentQuery(
                     collection.SelfLink,
                     query,
                     new FeedOptions
                     {
                         PopulateQueryMetrics = true,
                         MaxItemCount = -1
-                    }).AsDocumentQuery();
+                    }).AsDocumentQuery())
+                {
 
-                FeedResponse<dynamic> response = await documentQuery.ExecuteNextAsync();
-                return new QueryStats(response.Count, response.RequestCharge);
+                    FeedResponse<dynamic> response = await documentQuery.ExecuteNextAsync();
+                    return new QueryStats(response.Count, response.RequestCharge);
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
We have seen a memory leak in the following code pattern:

var query = client.CreateDocumentQuery<Model>(
                        uri,
                        new FeedOptions { EnableCrossPartitionQuery = true, MaxDegreeOfParallelism = -1, EnableScanInQuery = true })
                    .Where(where)
                    .Select(m => m.Id)
                    .AsDocumentQuery();

 while (query.HasMoreResults)
                    {
                        var executeNextResponse = await query.ExecuteNextAsync<string>();
                        (...)
                    }

For every call there was leftover in memory that was not collected:
![image](https://user-images.githubusercontent.com/5020041/68143084-eab5d480-feed-11e9-9d90-305d301569a7.png)

Disposing the query does take care of releasing the memory.

The proposed changes shows the user how to correctly dispose the query to prevent memory problems.