### PR TITLE
Correct minor typo in DocumentDb-Sdk_capture_etl

### DIFF
--- a/docs/documentdb-sdk_capture_etl.md
+++ b/docs/documentdb-sdk_capture_etl.md
@@ -10,7 +10,7 @@ Traces are emitted with DocDBTrace source. Below sample app.config configuration
       <source name="DocDBTrace" switchName="SourceSwitch" switchType="System.Diagnostics.SourceSwitch" >
         <listeners>
           <add name="MyTextListener" type="System.Diagnostics.TextWriterTraceListener" traceOutputOptions="DateTime,ProcessId,ThreadId" initializeData="CosmosDBTrace.txt"></add>
-       < /listeners>
+       </listeners>
       </source>
     </sources>
   </system.diagnostics> 


### PR DESCRIPTION
Extra space is incorrect.